### PR TITLE
Add basic onboarding flow

### DIFF
--- a/android-test-util/build.gradle.kts
+++ b/android-test-util/build.gradle.kts
@@ -44,8 +44,10 @@ dependencies {
     implementation(libs.kotlinx.coroutines.core)
     implementation(libs.kotlinx.coroutines.test)
     implementation(libs.junit4)
+    implementation(libs.assertj.core)
 
     implementation(libs.androidx.test.runner)
+    implementation(libs.androidx.navigation.testing)
 
     implementation(project.dependencies.platform(libs.koin.bom))
     implementation(libs.koin.android)

--- a/android-test-util/build.gradle.kts
+++ b/android-test-util/build.gradle.kts
@@ -20,30 +20,34 @@
  * OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-pluginManagement {
-    repositories {
-        google()
-        mavenCentral()
-        gradlePluginPortal()
+
+plugins {
+    alias(libs.plugins.android.library)
+    alias(libs.plugins.jetbrains.kotlin.android)
+    alias(libs.plugins.ksp)
+}
+
+android {
+    namespace = "net.opatry.test.util.android"
+    compileSdk = libs.versions.compileSdk.get().toInt()
+
+    defaultConfig {
+        minSdk = libs.versions.minSdk.get().toInt()
+    }
+
+    kotlin {
+        jvmToolchain(17)
     }
 }
 
-dependencyResolutionManagement {
-    @Suppress("UnstableApiUsage")
-    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
-    @Suppress("UnstableApiUsage")
-    repositories {
-        google()
-        mavenCentral()
-    }
+dependencies {
+    implementation(libs.kotlinx.coroutines.core)
+    implementation(libs.kotlinx.coroutines.test)
+    implementation(libs.junit4)
+
+    implementation(libs.androidx.test.runner)
+
+    implementation(project.dependencies.platform(libs.koin.bom))
+    implementation(libs.koin.android)
+    implementation(libs.koin.test)
 }
-
-enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
-
-rootProject.name = "H2Go"
-
-include(":h2go-app")
-include(":preferences") 
-include(":onboarding")
-include(":android-test-util")
-include(":test-util")

--- a/android-test-util/src/main/kotlin/net/opatry/test/util/android/KoinTestRule.kt
+++ b/android-test-util/src/main/kotlin/net/opatry/test/util/android/KoinTestRule.kt
@@ -20,30 +20,33 @@
  * OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-pluginManagement {
-    repositories {
-        google()
-        mavenCentral()
-        gradlePluginPortal()
+package net.opatry.test.util.android
+
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.rules.TestWatcher
+import org.junit.runner.Description
+import org.koin.android.ext.koin.androidContext
+import org.koin.core.context.GlobalContext.getKoinApplicationOrNull
+import org.koin.core.context.GlobalContext.startKoin
+import org.koin.core.context.GlobalContext.unloadKoinModules
+import org.koin.core.context.loadKoinModules
+import org.koin.core.module.Module
+
+class KoinTestRule(
+    private val modules: List<Module>
+) : TestWatcher() {
+    override fun starting(description: Description) {
+        if (getKoinApplicationOrNull() == null) {
+            startKoin {
+                androidContext(InstrumentationRegistry.getInstrumentation().targetContext.applicationContext)
+                modules(modules)
+            }
+        } else {
+            loadKoinModules(modules)
+        }
+    }
+
+    override fun finished(description: Description) {
+        unloadKoinModules(modules)
     }
 }
-
-dependencyResolutionManagement {
-    @Suppress("UnstableApiUsage")
-    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
-    @Suppress("UnstableApiUsage")
-    repositories {
-        google()
-        mavenCentral()
-    }
-}
-
-enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
-
-rootProject.name = "H2Go"
-
-include(":h2go-app")
-include(":preferences") 
-include(":onboarding")
-include(":android-test-util")
-include(":test-util")

--- a/android-test-util/src/main/kotlin/net/opatry/test/util/android/navigation/NavHostControllerTestExt.kt
+++ b/android-test-util/src/main/kotlin/net/opatry/test/util/android/navigation/NavHostControllerTestExt.kt
@@ -1,0 +1,12 @@
+package net.opatry.test.util.android.navigation
+
+import androidx.navigation.NavDestination.Companion.hasRoute
+import androidx.navigation.NavHostController
+import org.assertj.core.api.Assertions.assertThat
+
+
+inline fun <reified T : Any> NavHostController.assertRoute() {
+    assertThat(currentDestination?.hasRoute<T>())
+        .withFailMessage("Expected %s route but current route is %s", T::class.java.name, currentDestination?.route)
+        .isTrue()
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,8 +37,7 @@ plugins {
 }
 
 val koverProjects = listOf(
-    // Ignore app until there is really code to cover
-    // projects.h2goApp,
+    projects.h2goApp,
     projects.preferences,
     projects.onboarding,
 )
@@ -50,8 +49,17 @@ dependencies {
 }
 
 val koverExcludedClasses = listOf(
-    "net.opatry.h2go.app.di.*",
+    "net.opatry.h2go.app.data.H2GoDatabase*",
+    "net.opatry.h2go.app.data.di.*",
+    "net.opatry.h2go.app.navigation.*",
+    "net.opatry.h2go.app.ComposableSingletons*",
+    "net.opatry.h2go.app.H2GoApplication",
+    "net.opatry.h2go.preference.data.*Dao",
+    "net.opatry.h2go.preference.data.*Dao\$DefaultImpls",
     "net.opatry.h2go.preference.di.*",
+    "net.opatry.h2go.onboarding.di.*",
+    "net.opatry.h2go.onboarding.navigation.*",
+    "net.opatry.h2go.onboarding.ui.*",
 )
 
 kover {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,6 +40,7 @@ val koverProjects = listOf(
     // Ignore app until there is really code to cover
     // projects.h2goApp,
     projects.preferences,
+    projects.onboarding,
 )
 
 dependencies {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -62,6 +62,7 @@ compose-ui = { module = "androidx.compose.ui:ui" }
 compose-ui-graphics = { module = "androidx.compose.ui:ui-graphics" }
 
 androidx-navigation-compose = { module = "androidx.navigation:navigation-compose", version.ref = "navigation-compose" }
+androidx-navigation-testing = { module = "androidx.navigation:navigation-testing", version.ref = "navigation-compose" }
 
 androidx-test-core = { module = "androidx.test:core", version = "1.6.1" }
 androidx-ui-test-manifest = { module = "androidx.compose.ui:ui-test-manifest", version.ref = "compose" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,8 +10,8 @@ coroutines = "1.10.2"
 activity-compose = "1.11.0-rc01"
 compose-plugin = "1.8.1"
 compose = "1.8.2"
-compose-m3-adaptive = "1.1.1"
-compose-lifecycle = "2.9.0"
+compose-bom = "2025.06.00"
+navigation-compose = "2.9.0"
 material3 = "1.3.2"
 room = "2.7.1"
 sqlite = "2.5.1"
@@ -32,7 +32,7 @@ kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-t
 kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version = "0.6.2" }
 kotlinx-serialization = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version = "1.8.1" }
 
-androidx-material3 = { module = "androidx.compose.material3:material3", version.ref = "material3" }
+androidx-compose-material3 = { module = "androidx.compose.material3:material3", version.ref = "material3" }
 androidx-room-compiler = { module = "androidx.room:room-compiler", version.ref = "room" }
 androidx-room-common = { module = "androidx.room:room-common", version.ref = "room" }
 androidx-room-runtime = { module = "androidx.room:room-runtime", version.ref = "room" }
@@ -45,6 +45,7 @@ koin-bom = { module = "io.insert-koin:koin-bom", version.ref = "koin" }
 koin-core = { module = "io.insert-koin:koin-core" }
 koin-core-viewmodel = { module = "io.insert-koin:koin-core-viewmodel" }
 koin-android = { module = "io.insert-koin:koin-android" }
+koin-androidx-compose = { module = "io.insert-koin:koin-androidx-compose" }
 koin-androidx-startup = { module = "io.insert-koin:koin-androidx-startup" }
 koin-compose = { module = "io.insert-koin:koin-compose" }
 koin-compose-viewmodel = { module = "io.insert-koin:koin-compose-viewmodel" }
@@ -55,12 +56,19 @@ androidx-activity-compose = { module = "androidx.activity:activity-compose", ver
 
 about-libraries-core = { module = "com.mikepenz:aboutlibraries-core", version.ref = "about-libraries" }
 
+compose-bom = { module = "androidx.compose:compose-bom", version.ref = "compose-bom" }
+compose-ui = { module = "androidx.compose.ui:ui" }
+compose-ui-graphics = { module = "androidx.compose.ui:ui-graphics" }
+
+androidx-navigation-compose = { module = "androidx.navigation:navigation-compose", version.ref = "navigation-compose" }
+
 androidx-test-core = { module = "androidx.test:core", version = "1.6.1" }
 androidx-ui-test-manifest = { module = "androidx.compose.ui:ui-test-manifest", version.ref = "compose" }
 androidx-ui-test-junit4 = { module = "androidx.compose.ui:ui-test-junit4", version.ref = "compose" }
 androidx-test-runner = { module = "androidx.test:runner", version.ref = "androidx-test-runner" }
 
 mockito-core = { module = "org.mockito:mockito-core", version.ref = "mockito" }
+mockito-junit-jupiter = { module = "org.mockito:mockito-junit-jupiter", version.ref = "mockito-kotlin" }
 mockito-kotlin = { module = "org.mockito.kotlin:mockito-kotlin", version.ref = "mockito-kotlin" }
 
 androidx-ui-tooling-preview-android = { module = "androidx.compose.ui:ui-tooling-preview-android", version.ref = "compose" }
@@ -72,6 +80,7 @@ assertj-core = { module = "org.assertj:assertj-core", version.ref = "assertj" }
 [bundles]
 mockito = [
     "mockito-core",
+    "mockito-junit-jupiter",
     "mockito-kotlin",
 ]
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,6 +19,7 @@ koin = "4.1.0"
 about-libraries = "12.2.2"
 mockito = "5.18.0"
 mockito-kotlin = "5.4.0"
+junit4 = "4.13.2"
 junit = "5.10.2"
 assertj = "3.27.3"
 kover = "0.9.1"
@@ -74,6 +75,7 @@ mockito-kotlin = { module = "org.mockito.kotlin:mockito-kotlin", version.ref = "
 androidx-ui-tooling-preview-android = { module = "androidx.compose.ui:ui-tooling-preview-android", version.ref = "compose" }
 androidx-ui-tooling = { module = "androidx.compose.ui:ui-tooling", version.ref = "compose" }
 
+junit4 = { group = "junit", name = "junit", version.ref = "junit4" }
 junit = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit" }
 assertj-core = { module = "org.assertj:assertj-core", version.ref = "assertj" }
 

--- a/h2go-app/build.gradle.kts
+++ b/h2go-app/build.gradle.kts
@@ -136,6 +136,7 @@ dependencies {
     implementation(libs.androidx.ui.tooling)
     debugImplementation(libs.androidx.ui.test.manifest)
 
+    androidTestImplementation(projects.androidTestUtil)
     androidTestImplementation(libs.androidx.ui.test.junit4)
     androidTestImplementation(libs.androidx.test.runner)
 

--- a/h2go-app/build.gradle.kts
+++ b/h2go-app/build.gradle.kts
@@ -140,6 +140,10 @@ dependencies {
     androidTestImplementation(libs.androidx.ui.test.junit4)
     androidTestImplementation(libs.androidx.test.runner)
 
+    androidTestImplementation(libs.androidx.navigation.testing)
+    androidTestImplementation(libs.junit4)
+    androidTestImplementation(libs.assertj.core)
+
     testImplementation(libs.junit)
     testImplementation(libs.assertj.core)
     testImplementation(libs.koin.test)

--- a/h2go-app/build.gradle.kts
+++ b/h2go-app/build.gradle.kts
@@ -105,6 +105,7 @@ android {
 
 dependencies {
     implementation(projects.preferences)
+    implementation(projects.onboarding)
 
     implementation(libs.kotlinx.coroutines.android) {
         because("requires Dispatchers.Main & co at runtime for Android")
@@ -120,7 +121,9 @@ dependencies {
 
     implementation(libs.androidx.activity.compose)
 
-    implementation(libs.androidx.material3)
+    implementation(libs.androidx.navigation.compose)
+
+    implementation(libs.androidx.compose.material3)
     implementation(libs.androidx.appcompat)
 
     implementation(libs.kotlinx.serialization)

--- a/h2go-app/src/androidTest/java/net/opatry/h2go/app/navigation/MainNavigationTest.kt
+++ b/h2go-app/src/androidTest/java/net/opatry/h2go/app/navigation/MainNavigationTest.kt
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2025 Olivier Patry
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the Software
+ * is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE
+ * OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package net.opatry.h2go.app.navigation
+
+import androidx.activity.ComponentActivity
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.core.app.ActivityCompat.recreate
+import androidx.navigation.compose.ComposeNavigator
+import androidx.navigation.testing.TestNavHostController
+import net.opatry.h2go.data.di.databaseTestModule
+import net.opatry.h2go.onboarding.di.onboardingModule
+import net.opatry.h2go.onboarding.navigation.OnboardingRoutes
+import net.opatry.h2go.onboarding.ui.PreferencesScreenTestTag.SAVE_BUTTON
+import net.opatry.h2go.onboarding.ui.WelcomeScreenTestTag.CONTINUE_BUTTON
+import net.opatry.h2go.preference.di.preferencesModule
+import net.opatry.test.util.android.KoinTestRule
+import net.opatry.test.util.android.navigation.assertRoute
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+@OptIn(ExperimentalTestApi::class)
+class MainNavigationTest {
+    @get: Rule
+    val composeTestRule = createAndroidComposeRule<ComponentActivity>()
+
+    @get:Rule
+    val koinTestRule = KoinTestRule(
+        listOf(
+            databaseTestModule,
+            preferencesModule,
+            onboardingModule,
+        )
+    )
+
+    private lateinit var navController: TestNavHostController
+
+    @Before
+    fun setupNavHost() {
+        composeTestRule.setContent {
+            navController = TestNavHostController(LocalContext.current)
+            navController.navigatorProvider.addNavigator(ComposeNavigator())
+            MainNavigation(navController)
+        }
+    }
+
+    @Test
+    fun givenMainNavigation_shouldLandToWelcomeRoute() {
+        // Then
+        navController.assertRoute<OnboardingRoutes.Welcome>()
+    }
+
+    @Test
+    fun givenMainNavigation_whenClickingWelcomeButton_shouldNavigateToPreferencesRoute() {
+        // When
+        composeTestRule.onNodeWithTag(CONTINUE_BUTTON)
+            .performClick()
+        composeTestRule.waitForIdle()
+
+        // Then
+        navController.assertRoute<OnboardingRoutes.Preferences>()
+    }
+
+    @Test
+    fun givenPreferencesScreen_whenClickingSaveButton_shouldNavigateToMainRoute() {
+        // Given
+        composeTestRule.onNodeWithTag(CONTINUE_BUTTON)
+            .performClick()
+        composeTestRule.waitUntilExactlyOneExists(hasTestTag(SAVE_BUTTON))
+
+        // When
+        composeTestRule.onNodeWithTag(SAVE_BUTTON)
+            .performClick()
+        composeTestRule.waitForIdle()
+
+        // Then
+        navController.assertRoute<MainRoutes.Main>()
+    }
+
+    @Test
+    fun givenAchievedOnboarding_shouldLandToMainRoute() {
+        // Given
+        composeTestRule.onNodeWithTag(CONTINUE_BUTTON)
+            .performClick()
+        composeTestRule.waitUntilExactlyOneExists(hasTestTag(SAVE_BUTTON))
+
+        composeTestRule.onNodeWithTag(SAVE_BUTTON)
+            .performClick()
+        composeTestRule.waitForIdle()
+
+        // When
+        composeTestRule.activity.runOnUiThread {
+            // FIXME not really stressing app restart scenario
+            recreate(composeTestRule.activity)
+        }
+
+        // Then
+        navController.assertRoute<MainRoutes.Main>()
+    }
+}

--- a/h2go-app/src/androidTest/java/net/opatry/h2go/data/di/databaseTestModule.kt
+++ b/h2go-app/src/androidTest/java/net/opatry/h2go/data/di/databaseTestModule.kt
@@ -20,33 +20,19 @@
  * OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package net.opatry.h2go.app.navigation
+package net.opatry.h2go.data.di
 
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
-import androidx.navigation.NavHostController
-import androidx.navigation.compose.NavHost
-import androidx.navigation.compose.composable
-import androidx.navigation.compose.rememberNavController
-import net.opatry.h2go.onboarding.navigation.OnboardingRoutes
-import net.opatry.h2go.onboarding.navigation.onboardingNavigation
+import androidx.room.Room
+import net.opatry.h2go.app.data.H2GoDatabase
+import org.koin.dsl.module
 
-@Composable
-fun MainNavigation(navController: NavHostController = rememberNavController()) {
-    NavHost(navController, startDestination = OnboardingRoutes) {
-        onboardingNavigation(navController) {
-            navController.navigate(MainRoutes.Main) {
-                popUpTo<OnboardingRoutes>()
-            }
-        }
-        composable<MainRoutes.Main> {
-            Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                Text("MAIN SCREEN")
-            }
-        }
+val databaseTestModule = module {
+    single {
+        Room.inMemoryDatabaseBuilder<H2GoDatabase>(get())
+            .build()
+    }
+
+    single {
+        get<H2GoDatabase>().userPreferencesDao()
     }
 }

--- a/h2go-app/src/main/java/net/opatry/h2go/app/H2GoApplication.kt
+++ b/h2go-app/src/main/java/net/opatry/h2go/app/H2GoApplication.kt
@@ -24,6 +24,7 @@ package net.opatry.h2go.app
 
 import android.app.Application
 import net.opatry.h2go.app.data.di.databaseModule
+import net.opatry.h2go.onboarding.di.onboardingModule
 import net.opatry.h2go.preference.di.preferencesModule
 import org.koin.android.ext.koin.androidContext
 import org.koin.androix.startup.KoinStartup
@@ -38,6 +39,7 @@ class H2GoApplication : Application(), KoinStartup {
         modules(
             databaseModule,
             preferencesModule,
+            onboardingModule,
         )
     }
 }

--- a/h2go-app/src/main/java/net/opatry/h2go/app/navigation/MainNavigation.kt
+++ b/h2go-app/src/main/java/net/opatry/h2go/app/navigation/MainNavigation.kt
@@ -20,34 +20,33 @@
  * OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package net.opatry.h2go.app
+package net.opatry.h2go.app.navigation
 
-import android.os.Bundle
-import androidx.activity.ComponentActivity
-import androidx.activity.compose.setContent
-import androidx.activity.enableEdgeToEdge
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.statusBarsPadding
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import net.opatry.h2go.app.navigation.MainNavigation
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
+import net.opatry.h2go.onboarding.navigation.OnboardingRoutes
+import net.opatry.h2go.onboarding.navigation.onboardingNavigation
 
-class MainActivity : ComponentActivity() {
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
+@Composable
+fun MainNavigation() {
+    val navController = rememberNavController()
 
-        enableEdgeToEdge()
-
-        setContent {
-            MaterialTheme {
-                Surface(
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .statusBarsPadding(),
-                ) {
-                    MainNavigation()
-                }
+    NavHost(navController, startDestination = OnboardingRoutes) {
+        onboardingNavigation(navController) {
+            navController.navigate(MainRoutes.Main) {
+                popUpTo<OnboardingRoutes>()
+            }
+        }
+        composable<MainRoutes.Main> {
+            Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                Text("MAIN SCREEN")
             }
         }
     }

--- a/h2go-app/src/main/java/net/opatry/h2go/app/navigation/MainRoutes.kt
+++ b/h2go-app/src/main/java/net/opatry/h2go/app/navigation/MainRoutes.kt
@@ -20,35 +20,11 @@
  * OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package net.opatry.h2go.app
+package net.opatry.h2go.app.navigation
 
-import android.os.Bundle
-import androidx.activity.ComponentActivity
-import androidx.activity.compose.setContent
-import androidx.activity.enableEdgeToEdge
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.statusBarsPadding
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Surface
-import androidx.compose.ui.Modifier
-import net.opatry.h2go.app.navigation.MainNavigation
+import kotlinx.serialization.Serializable
 
-class MainActivity : ComponentActivity() {
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-
-        enableEdgeToEdge()
-
-        setContent {
-            MaterialTheme {
-                Surface(
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .statusBarsPadding(),
-                ) {
-                    MainNavigation()
-                }
-            }
-        }
-    }
+object MainRoutes {
+    @Serializable
+    data object Main
 }

--- a/onboarding/build.gradle.kts
+++ b/onboarding/build.gradle.kts
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2025 Olivier Patry
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the Software
+ * is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE
+ * OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+plugins {
+    alias(libs.plugins.android.library)
+    alias(libs.plugins.jetbrains.kotlin.android)
+    alias(libs.plugins.jetbrains.kotlin.compose.compiler)
+    alias(libs.plugins.jetbrains.kotlin.serialization)
+}
+
+android {
+    namespace = "net.opatry.h2go.onboarding"
+    compileSdk = libs.versions.compileSdk.get().toInt()
+
+    defaultConfig {
+        minSdk = libs.versions.minSdk.get().toInt()
+    }
+
+    kotlin {
+        jvmToolchain(17)
+    }
+
+    buildFeatures {
+        compose = true
+    }
+}
+
+dependencies {
+    implementation(projects.preferences)
+
+    implementation(platform(libs.koin.bom))
+    implementation(libs.koin.core)
+    implementation(libs.koin.android)
+    implementation(libs.koin.androidx.compose)
+
+    implementation(platform(libs.compose.bom))
+    implementation(libs.compose.ui)
+    implementation(libs.compose.ui.graphics)
+    implementation(libs.androidx.ui.tooling.preview.android)
+    implementation(libs.androidx.compose.material3)
+
+    implementation(libs.androidx.navigation.compose)
+
+    debugImplementation(libs.androidx.ui.tooling)
+    debugImplementation(libs.androidx.ui.test.manifest)
+
+    testImplementation(projects.testUtil)
+    testImplementation(libs.kotlinx.coroutines.test)
+    testImplementation(libs.junit)
+    testImplementation(libs.assertj.core)
+    testImplementation(libs.bundles.mockito)
+}

--- a/onboarding/build.gradle.kts
+++ b/onboarding/build.gradle.kts
@@ -68,4 +68,5 @@ dependencies {
     testImplementation(libs.junit)
     testImplementation(libs.assertj.core)
     testImplementation(libs.bundles.mockito)
+    testImplementation(libs.koin.test)
 }

--- a/onboarding/src/main/kotlin/net/opatry/h2go/onboarding/di/onboardingModule.kt
+++ b/onboarding/src/main/kotlin/net/opatry/h2go/onboarding/di/onboardingModule.kt
@@ -20,28 +20,22 @@
  * OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package net.opatry.h2go.app.di
+package net.opatry.h2go.onboarding.di
 
-import net.opatry.h2go.app.data.di.databaseModule
-import net.opatry.h2go.onboarding.di.onboardingModule
-import net.opatry.h2go.preference.di.preferencesModule
-import org.junit.jupiter.api.Test
-import org.koin.core.annotation.KoinExperimentalAPI
+import net.opatry.h2go.onboarding.domain.CheckUserPreferencesExistUseCase
+import net.opatry.h2go.onboarding.domain.SaveInitialUserPreferencesUseCase
+import net.opatry.h2go.onboarding.presentation.PreferencesViewModel
+import net.opatry.h2go.onboarding.presentation.UserVolumeUnitMapper
+import net.opatry.h2go.onboarding.presentation.WelcomeViewModel
+import org.koin.core.module.dsl.singleOf
+import org.koin.core.module.dsl.viewModelOf
 import org.koin.dsl.module
-import org.koin.test.verify.verify
 
-@OptIn(KoinExperimentalAPI::class)
-class H2GoDITest {
+val onboardingModule = module {
+    singleOf(::CheckUserPreferencesExistUseCase)
+    viewModelOf(::WelcomeViewModel)
 
-    @Test
-    fun `verify all modules`() {
-        val allModules = module {
-            includes(
-                databaseModule,
-                preferencesModule,
-                onboardingModule,
-            )
-        }
-        allModules.verify()
-    }
+    singleOf(::SaveInitialUserPreferencesUseCase)
+    singleOf(::UserVolumeUnitMapper)
+    viewModelOf(::PreferencesViewModel)
 }

--- a/onboarding/src/main/kotlin/net/opatry/h2go/onboarding/domain/CheckUserPreferencesExistUseCase.kt
+++ b/onboarding/src/main/kotlin/net/opatry/h2go/onboarding/domain/CheckUserPreferencesExistUseCase.kt
@@ -20,28 +20,13 @@
  * OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package net.opatry.h2go.app.di
+package net.opatry.h2go.onboarding.domain
 
-import net.opatry.h2go.app.data.di.databaseModule
-import net.opatry.h2go.onboarding.di.onboardingModule
-import net.opatry.h2go.preference.di.preferencesModule
-import org.junit.jupiter.api.Test
-import org.koin.core.annotation.KoinExperimentalAPI
-import org.koin.dsl.module
-import org.koin.test.verify.verify
+import kotlinx.coroutines.flow.firstOrNull
+import net.opatry.h2go.preference.domain.UserPreferencesRepository
 
-@OptIn(KoinExperimentalAPI::class)
-class H2GoDITest {
-
-    @Test
-    fun `verify all modules`() {
-        val allModules = module {
-            includes(
-                databaseModule,
-                preferencesModule,
-                onboardingModule,
-            )
-        }
-        allModules.verify()
-    }
-}
+class CheckUserPreferencesExistUseCase(
+    private val userPreferencesRepository: UserPreferencesRepository,
+) {
+    suspend operator fun invoke(): Boolean = userPreferencesRepository.getUserPreferences().firstOrNull() != null
+} 

--- a/onboarding/src/main/kotlin/net/opatry/h2go/onboarding/domain/SaveInitialUserPreferencesUseCase.kt
+++ b/onboarding/src/main/kotlin/net/opatry/h2go/onboarding/domain/SaveInitialUserPreferencesUseCase.kt
@@ -20,28 +20,34 @@
  * OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package net.opatry.h2go.preference.data
+package net.opatry.h2go.onboarding.domain
 
-import net.opatry.h2go.preference.data.entity.UserPreferencesEntity
 import net.opatry.h2go.preference.domain.UserPreferences
+import net.opatry.h2go.preference.domain.UserPreferencesRepository
 import net.opatry.h2go.preference.domain.VolumeUnit
-import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration
 
-class UserPreferencesMapper {
-
-    fun toDomain(entity: UserPreferencesEntity) = UserPreferences(
-        dailyTarget = entity.dailyTarget,
-        glassVolume = entity.glassVolume,
-        volumeUnit = VolumeUnit.valueOf(entity.volumeUnit),
-        areNotificationsEnabled = entity.areNotificationsEnabled,
-        notificationsFrequency = entity.notificationFrequencyInHours.hours,
-    )
-
-    fun toEntity(preferences: UserPreferences) = UserPreferencesEntity(
-        dailyTarget = preferences.dailyTarget,
-        glassVolume = preferences.glassVolume,
-        volumeUnit = preferences.volumeUnit.name,
-        areNotificationsEnabled = preferences.areNotificationsEnabled,
-        notificationFrequencyInHours = preferences.notificationsFrequency.inWholeHours.toInt(),
-    )
-}
+class SaveInitialUserPreferencesUseCase(
+    private val userPreferencesRepository: UserPreferencesRepository,
+) {
+    suspend operator fun invoke(
+        volumeUnit: VolumeUnit,
+        areNotificationsEnabled: Boolean,
+        notificationsFrequency: Duration,
+    ) {
+        val preferences = UserPreferences(
+            dailyTarget = when (volumeUnit) {
+                VolumeUnit.Milliliter -> 2000 // 2L
+                VolumeUnit.Oz -> 64 // 64 oz = ~2L
+            },
+            glassVolume = when (volumeUnit) {
+                VolumeUnit.Milliliter -> 250 // 250ml
+                VolumeUnit.Oz -> 8 // 8 oz = ~250ml
+            },
+            volumeUnit = volumeUnit,
+            areNotificationsEnabled = areNotificationsEnabled,
+            notificationsFrequency = notificationsFrequency,
+        )
+        userPreferencesRepository.updateUserPreferences(preferences)
+    }
+} 

--- a/onboarding/src/main/kotlin/net/opatry/h2go/onboarding/navigation/OnboardingNavigation.kt
+++ b/onboarding/src/main/kotlin/net/opatry/h2go/onboarding/navigation/OnboardingNavigation.kt
@@ -20,28 +20,35 @@
  * OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package net.opatry.h2go.app.di
+package net.opatry.h2go.onboarding.navigation
 
-import net.opatry.h2go.app.data.di.databaseModule
-import net.opatry.h2go.onboarding.di.onboardingModule
-import net.opatry.h2go.preference.di.preferencesModule
-import org.junit.jupiter.api.Test
-import org.koin.core.annotation.KoinExperimentalAPI
-import org.koin.dsl.module
-import org.koin.test.verify.verify
+import androidx.navigation.NavController
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.compose.composable
+import androidx.navigation.navigation
+import net.opatry.h2go.onboarding.ui.PreferencesScreen
+import net.opatry.h2go.onboarding.ui.WelcomeScreen
 
-@OptIn(KoinExperimentalAPI::class)
-class H2GoDITest {
-
-    @Test
-    fun `verify all modules`() {
-        val allModules = module {
-            includes(
-                databaseModule,
-                preferencesModule,
-                onboardingModule,
+fun NavGraphBuilder.onboardingNavigation(
+    navController: NavController,
+    onNavigateToMain: () -> Unit,
+) {
+    navigation<OnboardingRoutes>(startDestination = OnboardingRoutes.Welcome) {
+        composable<OnboardingRoutes.Welcome> {
+            WelcomeScreen(
+                onContinueClicked = {
+                    navController.navigate(OnboardingRoutes.Preferences) {
+                        popUpTo<OnboardingRoutes.Welcome> { inclusive = true }
+                    }
+                },
+                onNavigateToMain = onNavigateToMain,
             )
         }
-        allModules.verify()
+
+        composable<OnboardingRoutes.Preferences> {
+            PreferencesScreen(
+                onNavigateToMain = onNavigateToMain,
+            )
+        }
     }
 }

--- a/onboarding/src/main/kotlin/net/opatry/h2go/onboarding/navigation/OnboardingRoutes.kt
+++ b/onboarding/src/main/kotlin/net/opatry/h2go/onboarding/navigation/OnboardingRoutes.kt
@@ -20,28 +20,16 @@
  * OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package net.opatry.h2go.app.di
+package net.opatry.h2go.onboarding.navigation
 
-import net.opatry.h2go.app.data.di.databaseModule
-import net.opatry.h2go.onboarding.di.onboardingModule
-import net.opatry.h2go.preference.di.preferencesModule
-import org.junit.jupiter.api.Test
-import org.koin.core.annotation.KoinExperimentalAPI
-import org.koin.dsl.module
-import org.koin.test.verify.verify
+import kotlinx.serialization.Serializable
 
-@OptIn(KoinExperimentalAPI::class)
-class H2GoDITest {
+@Serializable
+object OnboardingRoutes {
 
-    @Test
-    fun `verify all modules`() {
-        val allModules = module {
-            includes(
-                databaseModule,
-                preferencesModule,
-                onboardingModule,
-            )
-        }
-        allModules.verify()
-    }
+    @Serializable
+    data object Welcome
+
+    @Serializable
+    data object Preferences
 }

--- a/onboarding/src/main/kotlin/net/opatry/h2go/onboarding/presentation/PreferencesEvent.kt
+++ b/onboarding/src/main/kotlin/net/opatry/h2go/onboarding/presentation/PreferencesEvent.kt
@@ -1,0 +1,6 @@
+package net.opatry.h2go.onboarding.presentation
+
+sealed interface PreferencesEvent {
+    data object NavigateToMain : PreferencesEvent
+    data class Error(val message: String): PreferencesEvent
+}

--- a/onboarding/src/main/kotlin/net/opatry/h2go/onboarding/presentation/PreferencesUiState.kt
+++ b/onboarding/src/main/kotlin/net/opatry/h2go/onboarding/presentation/PreferencesUiState.kt
@@ -20,28 +20,15 @@
  * OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package net.opatry.h2go.app.di
+package net.opatry.h2go.onboarding.presentation
 
-import net.opatry.h2go.app.data.di.databaseModule
-import net.opatry.h2go.onboarding.di.onboardingModule
-import net.opatry.h2go.preference.di.preferencesModule
-import org.junit.jupiter.api.Test
-import org.koin.core.annotation.KoinExperimentalAPI
-import org.koin.dsl.module
-import org.koin.test.verify.verify
+import kotlin.time.Duration
 
-@OptIn(KoinExperimentalAPI::class)
-class H2GoDITest {
 
-    @Test
-    fun `verify all modules`() {
-        val allModules = module {
-            includes(
-                databaseModule,
-                preferencesModule,
-                onboardingModule,
-            )
-        }
-        allModules.verify()
-    }
-}
+data class PreferencesUiState(
+    val selectedVolumeUnit: UserVolumeUnit,
+    val areNotificationsEnabled: Boolean,
+    val notificationsFrequency: Duration,
+    val notificationsFrequencyBounds: ClosedRange<Duration>,
+    val isSaving: Boolean,
+)

--- a/onboarding/src/main/kotlin/net/opatry/h2go/onboarding/presentation/PreferencesViewModel.kt
+++ b/onboarding/src/main/kotlin/net/opatry/h2go/onboarding/presentation/PreferencesViewModel.kt
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2025 Olivier Patry
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the Software
+ * is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE
+ * OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package net.opatry.h2go.onboarding.presentation
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import net.opatry.h2go.onboarding.domain.SaveInitialUserPreferencesUseCase
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.hours
+
+class PreferencesViewModel(
+    private val saveInitialUserPreferencesUseCase: SaveInitialUserPreferencesUseCase,
+    private val volumeMapper: UserVolumeUnitMapper,
+) : ViewModel() {
+
+    // TODO get default preferences from domain
+    private val _uiState = MutableStateFlow(
+        PreferencesUiState(
+            // FIXME depends on Locale
+            // FIXME presentation layer version?
+            selectedVolumeUnit = UserVolumeUnit.Milliliter,
+            areNotificationsEnabled = true,
+            notificationsFrequency = 2.hours,
+            notificationsFrequencyBounds = 1.hours..6.hours,
+            isSaving = false,
+        )
+    )
+    val uiState = _uiState.asStateFlow()
+
+    private val _eventsFlow = MutableSharedFlow<PreferencesEvent>()
+    val eventsFlow = _eventsFlow.asSharedFlow()
+
+    fun updateVolumeUnit(unit: UserVolumeUnit) {
+        _uiState.update { it.copy(selectedVolumeUnit = unit) }
+    }
+
+    fun enableNotifications(enabled: Boolean) {
+        _uiState.update { it.copy(areNotificationsEnabled = enabled) }
+    }
+
+    fun updateNotificationsFrequency(frequency: Duration) {
+        _uiState.update { it.copy(notificationsFrequency = frequency) }
+    }
+
+    fun savePreferences() {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isSaving = true) }
+            runCatching {
+                saveInitialUserPreferencesUseCase(
+                    volumeUnit = volumeMapper.toDomain(uiState.value.selectedVolumeUnit),
+                    areNotificationsEnabled = uiState.value.areNotificationsEnabled,
+                    notificationsFrequency = uiState.value.notificationsFrequency,
+                )
+            }.fold(
+                onSuccess = {
+                    _uiState.update { it.copy(isSaving = false) }
+                    _eventsFlow.emit(PreferencesEvent.NavigateToMain)
+                }, onFailure = { e ->
+                    _uiState.update { it.copy(isSaving = false) }
+                    _eventsFlow.emit(PreferencesEvent.Error(e.message ?: "Unknown error"))
+                }
+            )
+        }
+    }
+}

--- a/onboarding/src/main/kotlin/net/opatry/h2go/onboarding/presentation/UserVolumeUnit.kt
+++ b/onboarding/src/main/kotlin/net/opatry/h2go/onboarding/presentation/UserVolumeUnit.kt
@@ -1,0 +1,22 @@
+package net.opatry.h2go.onboarding.presentation
+
+import androidx.annotation.StringRes
+import net.opatry.h2go.onboarding.R
+
+// TODO change as "value+unit" and add Glass unit
+//  then convert to ml or oz for domain layer
+//  would let users choose a value with meaning for them
+sealed interface UserVolumeUnit {
+    @get:StringRes
+    val labelRes: Int
+
+    data object Milliliter : UserVolumeUnit {
+        override val labelRes: Int
+            get() = R.string.onboarding_preferences_volume_unit_ml
+    }
+
+    data object Oz : UserVolumeUnit {
+        override val labelRes: Int
+            get() = R.string.onboarding_preferences_volume_unit_oz
+    }
+}

--- a/onboarding/src/main/kotlin/net/opatry/h2go/onboarding/presentation/UserVolumeUnitMapper.kt
+++ b/onboarding/src/main/kotlin/net/opatry/h2go/onboarding/presentation/UserVolumeUnitMapper.kt
@@ -1,0 +1,15 @@
+package net.opatry.h2go.onboarding.presentation
+
+import net.opatry.h2go.preference.domain.VolumeUnit
+
+class UserVolumeUnitMapper {
+    fun toPresentation(unit: VolumeUnit) = when(unit) {
+        VolumeUnit.Milliliter -> UserVolumeUnit.Milliliter
+        VolumeUnit.Oz -> UserVolumeUnit.Oz
+    }
+
+    fun toDomain(unit: UserVolumeUnit) = when(unit) {
+        UserVolumeUnit.Milliliter -> VolumeUnit.Milliliter
+        UserVolumeUnit.Oz -> VolumeUnit.Oz
+    }
+}

--- a/onboarding/src/main/kotlin/net/opatry/h2go/onboarding/presentation/WelcomeUiState.kt
+++ b/onboarding/src/main/kotlin/net/opatry/h2go/onboarding/presentation/WelcomeUiState.kt
@@ -20,28 +20,11 @@
  * OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package net.opatry.h2go.app.di
+package net.opatry.h2go.onboarding.presentation
 
-import net.opatry.h2go.app.data.di.databaseModule
-import net.opatry.h2go.onboarding.di.onboardingModule
-import net.opatry.h2go.preference.di.preferencesModule
-import org.junit.jupiter.api.Test
-import org.koin.core.annotation.KoinExperimentalAPI
-import org.koin.dsl.module
-import org.koin.test.verify.verify
 
-@OptIn(KoinExperimentalAPI::class)
-class H2GoDITest {
-
-    @Test
-    fun `verify all modules`() {
-        val allModules = module {
-            includes(
-                databaseModule,
-                preferencesModule,
-                onboardingModule,
-            )
-        }
-        allModules.verify()
-    }
+sealed interface WelcomeUiState {
+    data object Idle : WelcomeUiState
+    data object ShowWelcome : WelcomeUiState
+    data object NavigateToMain : WelcomeUiState
 }

--- a/onboarding/src/main/kotlin/net/opatry/h2go/onboarding/presentation/WelcomeViewModel.kt
+++ b/onboarding/src/main/kotlin/net/opatry/h2go/onboarding/presentation/WelcomeViewModel.kt
@@ -20,28 +20,31 @@
  * OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package net.opatry.h2go.app.di
+package net.opatry.h2go.onboarding.presentation
 
-import net.opatry.h2go.app.data.di.databaseModule
-import net.opatry.h2go.onboarding.di.onboardingModule
-import net.opatry.h2go.preference.di.preferencesModule
-import org.junit.jupiter.api.Test
-import org.koin.core.annotation.KoinExperimentalAPI
-import org.koin.dsl.module
-import org.koin.test.verify.verify
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import net.opatry.h2go.onboarding.domain.CheckUserPreferencesExistUseCase
 
-@OptIn(KoinExperimentalAPI::class)
-class H2GoDITest {
+class WelcomeViewModel(
+    private val checkUserPreferencesExistUseCase: CheckUserPreferencesExistUseCase,
+) : ViewModel() {
 
-    @Test
-    fun `verify all modules`() {
-        val allModules = module {
-            includes(
-                databaseModule,
-                preferencesModule,
-                onboardingModule,
-            )
+    private val _uiState = MutableStateFlow<WelcomeUiState>(WelcomeUiState.Idle)
+    val uiState: StateFlow<WelcomeUiState> = _uiState.asStateFlow()
+
+    fun checkUserPreferences() {
+        viewModelScope.launch {
+            _uiState.value = checkUserPreferencesExistUseCase().let { exists ->
+                when {
+                    exists -> WelcomeUiState.NavigateToMain
+                    else -> WelcomeUiState.ShowWelcome
+                }
+            }
         }
-        allModules.verify()
     }
 }

--- a/onboarding/src/main/kotlin/net/opatry/h2go/onboarding/ui/PreferencesScreen.kt
+++ b/onboarding/src/main/kotlin/net/opatry/h2go/onboarding/ui/PreferencesScreen.kt
@@ -1,0 +1,286 @@
+/*
+ * Copyright (c) 2025 Olivier Patry
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the Software
+ * is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE
+ * OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package net.opatry.h2go.onboarding.ui
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.selection.selectable
+import androidx.compose.foundation.selection.selectableGroup
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.RadioButton
+import androidx.compose.material3.Slider
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.pluralStringResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.tooling.preview.PreviewParameterProvider
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import net.opatry.h2go.onboarding.R
+import net.opatry.h2go.onboarding.presentation.PreferencesEvent
+import net.opatry.h2go.onboarding.presentation.PreferencesUiState
+import net.opatry.h2go.onboarding.presentation.PreferencesViewModel
+import net.opatry.h2go.onboarding.presentation.UserVolumeUnit
+import org.koin.androidx.compose.koinViewModel
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.hours
+
+@Composable
+fun PreferencesScreen(
+    onNavigateToMain: () -> Unit,
+    viewModel: PreferencesViewModel = koinViewModel(),
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    var error by remember { mutableStateOf<String?>(null) }
+
+    LaunchedEffect(Unit) {
+        viewModel.eventsFlow.collect { event ->
+            when (event) {
+                is PreferencesEvent.Error -> error = event.message
+                PreferencesEvent.NavigateToMain -> onNavigateToMain()
+            }
+        }
+    }
+
+    error?.let { errorMessage ->
+        AlertDialog(
+            onDismissRequest = { error = null },
+            title = { Text(text = stringResource(R.string.onboarding_error_title)) },
+            text = { Text(text = errorMessage) },
+            confirmButton = {
+                Button(onClick = { error = null }) {
+                    Text(text = stringResource(android.R.string.ok))
+                }
+            },
+        )
+    }
+
+    PreferencesScreen(
+        uiState = uiState,
+        onVolumeUnitSelected = viewModel::updateVolumeUnit,
+        onNotificationsEnabledChanged = viewModel::enableNotifications,
+        onNotificationFrequencyChanged = viewModel::updateNotificationsFrequency,
+        onSaveClicked = viewModel::savePreferences,
+    )
+}
+
+@Composable
+fun PreferencesScreen(
+    uiState: PreferencesUiState,
+    onVolumeUnitSelected: (UserVolumeUnit) -> Unit,
+    onNotificationsEnabledChanged: (Boolean) -> Unit,
+    onNotificationFrequencyChanged: (Duration) -> Unit,
+    onSaveClicked: () -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp)
+            .verticalScroll(rememberScrollState()),
+    ) {
+        Text(
+            text = stringResource(R.string.onboarding_preferences_title),
+            style = MaterialTheme.typography.headlineMedium,
+        )
+        Spacer(modifier = Modifier.height(32.dp))
+
+        Text(
+            text = stringResource(R.string.onboarding_preferences_volume_unit_title),
+            style = MaterialTheme.typography.titleMedium,
+        )
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .selectableGroup(),
+        ) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(vertical = 8.dp),
+                horizontalArrangement = Arrangement.spacedBy(16.dp)
+            ) {
+                listOf(UserVolumeUnit.Milliliter, UserVolumeUnit.Oz).forEach { unit ->
+                    val isSelected = unit == uiState.selectedVolumeUnit
+                    Row(
+                        modifier = Modifier
+                            .weight(1f)
+                            .selectable(
+                                selected = isSelected,
+                                onClick = { onVolumeUnitSelected(unit) },
+                                role = Role.RadioButton,
+                            ),
+                        horizontalArrangement = Arrangement.spacedBy(8.dp)
+                    ) {
+                        RadioButton(
+                            selected = isSelected,
+                            onClick = null,
+                        )
+                        Text(
+                            text = stringResource(unit.labelRes),
+                            style = MaterialTheme.typography.bodyLarge,
+                        )
+                    }
+                }
+            }
+        }
+
+        Spacer(modifier = Modifier.height(32.dp))
+
+        Text(
+            text = stringResource(R.string.onboarding_preferences_notifications_title),
+            style = MaterialTheme.typography.titleMedium,
+        )
+        Column(
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp), verticalAlignment = Alignment.CenterVertically) {
+                Text(
+                    text = stringResource(R.string.onboarding_preferences_notifications_enable),
+                    modifier = Modifier.weight(1f),
+                )
+                Switch(
+                    checked = uiState.areNotificationsEnabled,
+                    onCheckedChange = { onNotificationsEnabledChanged(it) },
+                )
+            }
+            AnimatedVisibility(visible = uiState.areNotificationsEnabled) {
+                Column {
+                    Spacer(modifier = Modifier.height(16.dp))
+                    Text(
+                        text = stringResource(R.string.onboarding_preferences_notification_frequency_title),
+                        style = MaterialTheme.typography.bodyLarge,
+                    )
+                    val frequencyInHours = uiState.notificationsFrequency.inWholeHours.toInt()
+                    val frequencyBoundsInHours = uiState.notificationsFrequencyBounds.let {
+                        it.start.inWholeHours.toFloat()..it.endInclusive.inWholeHours.toFloat()
+                    }
+                    val frequencySteps = with(uiState.notificationsFrequencyBounds) {
+                        endInclusive.inWholeHours - start.inWholeHours - 1
+                    }.coerceAtLeast(0).toInt()
+                    Slider(
+                        value = uiState.notificationsFrequency.inWholeHours.toFloat(),
+                        onValueChange = { onNotificationFrequencyChanged(it.toInt().hours) },
+                        valueRange = frequencyBoundsInHours,
+                        steps = frequencySteps,
+                        modifier = Modifier.padding(horizontal = 16.dp),
+                    )
+                    Text(
+                        text = pluralStringResource(
+                            R.plurals.onboarding_preferences_notification_frequency_value,
+                            frequencyInHours,
+                            frequencyInHours,
+                        ),
+                        style = MaterialTheme.typography.bodyMedium,
+                        modifier = Modifier.padding(horizontal = 16.dp),
+                    )
+                }
+            }
+        }
+
+        Spacer(modifier = Modifier.weight(1f))
+
+        Button(
+            onClick = onSaveClicked,
+            modifier = Modifier.fillMaxWidth(),
+            enabled = !uiState.isSaving,
+        ) {
+            if (uiState.isSaving) {
+                CircularProgressIndicator(
+                    modifier = Modifier.padding(end = 8.dp),
+                    color = MaterialTheme.colorScheme.onPrimary,
+                )
+            }
+            Text(text = stringResource(R.string.onboarding_preferences_save_button))
+        }
+    }
+}
+
+private class PreferencesPreviewParameterProvider : PreviewParameterProvider<PreferencesUiState> {
+    override val values: Sequence<PreferencesUiState>
+        get() = sequenceOf(
+            PreferencesUiState(
+                selectedVolumeUnit = UserVolumeUnit.Milliliter,
+                areNotificationsEnabled = false,
+                notificationsFrequency = 1.hours,
+                notificationsFrequencyBounds = 1.hours..6.hours,
+                isSaving = false,
+            ),
+            PreferencesUiState(
+                selectedVolumeUnit = UserVolumeUnit.Oz,
+                areNotificationsEnabled = true,
+                notificationsFrequency = 7.hours,
+                notificationsFrequencyBounds = 1.hours..12.hours,
+                isSaving = false,
+            ),
+            PreferencesUiState(
+                selectedVolumeUnit = UserVolumeUnit.Oz,
+                areNotificationsEnabled = true,
+                notificationsFrequency = 2.hours,
+                notificationsFrequencyBounds = 1.hours..6.hours,
+                isSaving = true,
+            ),
+        )
+}
+
+@PreviewLightDark
+@Composable
+private fun PreferencesScreenPreview(
+    @PreviewParameter(PreferencesPreviewParameterProvider::class)
+    uiState: PreferencesUiState
+) {
+    MaterialTheme {
+        Surface {
+            PreferencesScreen(
+                uiState = uiState,
+                onVolumeUnitSelected = {},
+                onNotificationsEnabledChanged = {},
+                onNotificationFrequencyChanged = {},
+                onSaveClicked = {},
+            )
+        }
+    }
+} 

--- a/onboarding/src/main/kotlin/net/opatry/h2go/onboarding/ui/PreferencesScreen.kt
+++ b/onboarding/src/main/kotlin/net/opatry/h2go/onboarding/ui/PreferencesScreen.kt
@@ -22,6 +22,7 @@
 
 package net.opatry.h2go.onboarding.ui
 
+import androidx.annotation.VisibleForTesting
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -52,6 +53,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
@@ -65,9 +67,15 @@ import net.opatry.h2go.onboarding.presentation.PreferencesEvent
 import net.opatry.h2go.onboarding.presentation.PreferencesUiState
 import net.opatry.h2go.onboarding.presentation.PreferencesViewModel
 import net.opatry.h2go.onboarding.presentation.UserVolumeUnit
+import net.opatry.h2go.onboarding.ui.PreferencesScreenTestTag.SAVE_BUTTON
 import org.koin.androidx.compose.koinViewModel
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.hours
+
+@VisibleForTesting
+object PreferencesScreenTestTag {
+    const val SAVE_BUTTON = "PREFERENCES_SAVE_BUTTON"
+}
 
 @Composable
 fun PreferencesScreen(
@@ -225,16 +233,19 @@ fun PreferencesScreen(
 
         Button(
             onClick = onSaveClicked,
-            modifier = Modifier.fillMaxWidth(),
+            modifier = Modifier
+                .fillMaxWidth()
+                .testTag(SAVE_BUTTON),
             enabled = !uiState.isSaving,
         ) {
-            if (uiState.isSaving) {
-                CircularProgressIndicator(
-                    modifier = Modifier.padding(end = 8.dp),
-                    color = MaterialTheme.colorScheme.onPrimary,
-                )
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                Text(text = stringResource(R.string.onboarding_preferences_save_button))
+                AnimatedVisibility(visible = uiState.isSaving) {
+                    CircularProgressIndicator(
+                        color = MaterialTheme.colorScheme.onPrimary,
+                    )
+                }
             }
-            Text(text = stringResource(R.string.onboarding_preferences_save_button))
         }
     }
 }

--- a/onboarding/src/main/kotlin/net/opatry/h2go/onboarding/ui/WelcomeScreen.kt
+++ b/onboarding/src/main/kotlin/net/opatry/h2go/onboarding/ui/WelcomeScreen.kt
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2025 Olivier Patry
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the Software
+ * is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE
+ * OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package net.opatry.h2go.onboarding.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import net.opatry.h2go.onboarding.R
+import net.opatry.h2go.onboarding.presentation.WelcomeUiState
+import net.opatry.h2go.onboarding.presentation.WelcomeViewModel
+import org.koin.androidx.compose.koinViewModel
+
+@Composable
+fun WelcomeScreen(
+    viewModel: WelcomeViewModel = koinViewModel(),
+    onContinueClicked: () -> Unit,
+    onNavigateToMain: () -> Unit,
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    when (uiState) {
+        WelcomeUiState.Idle -> LaunchedEffect(uiState) {
+            viewModel.checkUserPreferences()
+        }
+
+        WelcomeUiState.NavigateToMain -> onNavigateToMain()
+        WelcomeUiState.ShowWelcome -> WelcomeScreen(onContinueClicked = onContinueClicked)
+    }
+}
+
+@Composable
+fun WelcomeScreen(
+    onContinueClicked: () -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(32.dp, Alignment.CenterVertically),
+    ) {
+        Text(
+            text = stringResource(R.string.onboarding_welcome_title),
+            style = MaterialTheme.typography.headlineLarge,
+            textAlign = TextAlign.Center,
+        )
+        Text(
+            text = stringResource(R.string.onboarding_welcome_message),
+            style = MaterialTheme.typography.bodyLarge,
+            textAlign = TextAlign.Center,
+        )
+        Button(
+            onClick = onContinueClicked,
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Text(text = stringResource(R.string.onboarding_welcome_continue_button))
+        }
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun WelcomeScreenContentPreview() {
+    MaterialTheme {
+        Surface {
+            WelcomeScreen(
+                onContinueClicked = {},
+            )
+        }
+    }
+}

--- a/onboarding/src/main/kotlin/net/opatry/h2go/onboarding/ui/WelcomeScreen.kt
+++ b/onboarding/src/main/kotlin/net/opatry/h2go/onboarding/ui/WelcomeScreen.kt
@@ -22,6 +22,7 @@
 
 package net.opatry.h2go.onboarding.ui
 
+import androidx.annotation.VisibleForTesting
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
@@ -36,6 +37,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.PreviewLightDark
@@ -44,7 +46,13 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import net.opatry.h2go.onboarding.R
 import net.opatry.h2go.onboarding.presentation.WelcomeUiState
 import net.opatry.h2go.onboarding.presentation.WelcomeViewModel
+import net.opatry.h2go.onboarding.ui.WelcomeScreenTestTag.CONTINUE_BUTTON
 import org.koin.androidx.compose.koinViewModel
+
+@VisibleForTesting
+object WelcomeScreenTestTag {
+    const val CONTINUE_BUTTON = "WELCOME_CONTINUE_BUTTON"
+}
 
 @Composable
 fun WelcomeScreen(
@@ -87,7 +95,9 @@ fun WelcomeScreen(
         )
         Button(
             onClick = onContinueClicked,
-            modifier = Modifier.fillMaxWidth(),
+            modifier = Modifier
+                .fillMaxWidth()
+                .testTag(CONTINUE_BUTTON),
         ) {
             Text(text = stringResource(R.string.onboarding_welcome_continue_button))
         }

--- a/onboarding/src/main/res/values/strings.xml
+++ b/onboarding/src/main/res/values/strings.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  Copyright (c) 2025 Olivier Patry
+
+  Permission is hereby granted, free of charge, to any person obtaining
+  a copy of this software and associated documentation files (the "Software"),
+  to deal in the Software without restriction, including without limitation
+  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+  and/or sell copies of the Software, and to permit persons to whom the Software
+  is furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+  IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+  CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+  TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE
+  OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+  -->
+
+<resources>
+    <string name="onboarding_welcome_title">Start your healthy journey</string>
+    <string name="onboarding_welcome_message">H₂Go! is designed to be simple, fast, and supportive. Just one tap to log your water, right from the app or your home screen.\n\n</string>
+    <string name="onboarding_welcome_continue_button">Continue</string>
+
+    <string name="onboarding_preferences_title">Your preferences</string>
+    <string name="onboarding_preferences_volume_unit_title">Volume unit</string>
+    <string name="onboarding_preferences_volume_unit_ml">Milliliters</string>
+    <string name="onboarding_preferences_volume_unit_oz">Oz</string>
+    <string name="onboarding_preferences_notifications_title">Notifications</string>
+    <string name="onboarding_preferences_notifications_enable">Enable notifications</string>
+    <string name="onboarding_preferences_notification_frequency_title">Frequency</string>
+    <plurals name="onboarding_preferences_notification_frequency_value">
+        <item quantity="one">Every hour</item>
+        <item quantity="other">Every %1$d hours</item>
+    </plurals>
+    <string name="onboarding_preferences_save_button">Save</string>
+
+    <string name="onboarding_error_title">Error</string>
+</resources>

--- a/onboarding/src/test/kotlin/net/opatry/h2go/onboarding/di/OnboardingModuleTest.kt
+++ b/onboarding/src/test/kotlin/net/opatry/h2go/onboarding/di/OnboardingModuleTest.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2025 Olivier Patry
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the Software
+ * is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE
+ * OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package net.opatry.h2go.onboarding.di
+
+import net.opatry.h2go.onboarding.domain.CheckUserPreferencesExistUseCase
+import net.opatry.h2go.onboarding.domain.SaveInitialUserPreferencesUseCase
+import net.opatry.h2go.preference.domain.UserPreferencesRepository
+import org.junit.jupiter.api.Test
+import org.koin.core.annotation.KoinExperimentalAPI
+import org.koin.test.verify.definition
+import org.koin.test.verify.injectedParameters
+import org.koin.test.verify.verify
+
+@OptIn(KoinExperimentalAPI::class)
+class OnboardingModuleTest {
+
+    @Test
+    fun `verify onboarding module`() {
+        onboardingModule.verify(
+            injections = injectedParameters(
+                definition<CheckUserPreferencesExistUseCase>(UserPreferencesRepository::class),
+                definition<SaveInitialUserPreferencesUseCase>(UserPreferencesRepository::class),
+            )
+        )
+    }
+}

--- a/onboarding/src/test/kotlin/net/opatry/h2go/onboarding/domain/CheckUserPreferencesExistUseCaseTest.kt
+++ b/onboarding/src/test/kotlin/net/opatry/h2go/onboarding/domain/CheckUserPreferencesExistUseCaseTest.kt
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2025 Olivier Patry
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the Software
+ * is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE
+ * OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package net.opatry.h2go.onboarding.domain
+
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import net.opatry.h2go.preference.domain.UserPreferences
+import net.opatry.h2go.preference.domain.UserPreferencesRepository
+import net.opatry.h2go.preference.domain.VolumeUnit
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.given
+import kotlin.time.Duration.Companion.hours
+
+@ExtendWith(MockitoExtension::class)
+class CheckUserPreferencesExistUseCaseTest {
+
+    @Mock
+    private lateinit var repository: UserPreferencesRepository
+
+    @InjectMocks
+    private lateinit var useCase: CheckUserPreferencesExistUseCase
+
+    @Test
+    fun `given existing preferences, when checking preferences existence, then should return true`() = runTest {
+        // Given
+        val preferences = UserPreferences(
+            dailyTarget = 2000,
+            glassVolume = 250,
+            volumeUnit = VolumeUnit.Milliliter,
+            areNotificationsEnabled = true,
+            notificationsFrequency = 2.hours,
+        )
+        given(repository.getUserPreferences()).willReturn(flowOf(preferences))
+
+        // When
+        val result = useCase()
+
+        // Then
+        assertThat(result).isTrue()
+    }
+
+    @Test
+    fun `given no existing preferences, when checking preferences existence, then should return false`() = runTest {
+        // Given
+        given(repository.getUserPreferences()).willReturn(flowOf(null))
+
+        // When
+        val result = useCase()
+
+        // Then
+        assertThat(result).isFalse()
+    }
+} 

--- a/onboarding/src/test/kotlin/net/opatry/h2go/onboarding/domain/SaveInitialUserPreferencesUseCaseTest.kt
+++ b/onboarding/src/test/kotlin/net/opatry/h2go/onboarding/domain/SaveInitialUserPreferencesUseCaseTest.kt
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2025 Olivier Patry
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the Software
+ * is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE
+ * OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package net.opatry.h2go.onboarding.domain
+
+import kotlinx.coroutines.test.runTest
+import net.opatry.h2go.preference.domain.UserPreferences
+import net.opatry.h2go.preference.domain.UserPreferencesRepository
+import net.opatry.h2go.preference.domain.VolumeUnit
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.verify
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.hours
+
+@ExtendWith(MockitoExtension::class)
+class SaveInitialUserPreferencesUseCaseTest {
+
+    data class PreferencesParam(
+        val dailyTarget: Int,
+        val glassVolume: Int,
+        val volumeUnit: VolumeUnit,
+        val areNotificationsEnabled: Boolean,
+        val notificationsFrequency: Duration,
+    )
+
+    companion object {
+        @JvmStatic
+        fun preferenceParams() = arrayOf(
+            PreferencesParam(
+                dailyTarget = 2000,
+                glassVolume = 250,
+                volumeUnit = VolumeUnit.Milliliter,
+                areNotificationsEnabled = true,
+                notificationsFrequency = 2.hours,
+            ),
+            PreferencesParam(
+                dailyTarget = 64,
+                glassVolume = 8,
+                volumeUnit = VolumeUnit.Oz,
+                areNotificationsEnabled = false,
+                notificationsFrequency = 4.hours,
+            ),
+        )
+    }
+
+    @Mock
+    private lateinit var repository: UserPreferencesRepository
+
+    @InjectMocks
+    private lateinit var useCase: SaveInitialUserPreferencesUseCase
+
+    @ParameterizedTest(name = "given {0}, when saving user preferences, then should update repository with given data")
+    @MethodSource("preferenceParams")
+    fun saveUserPreferences(
+        // Given
+        givenParam: PreferencesParam,
+    ) = runTest {
+
+        // When
+        useCase(
+            volumeUnit = givenParam.volumeUnit,
+            areNotificationsEnabled = givenParam.areNotificationsEnabled,
+            notificationsFrequency = givenParam.notificationsFrequency,
+        )
+
+        // Then
+        verify(repository).updateUserPreferences(
+            UserPreferences(
+                dailyTarget = givenParam.dailyTarget,
+                glassVolume = givenParam.glassVolume,
+                volumeUnit = givenParam.volumeUnit,
+                areNotificationsEnabled = givenParam.areNotificationsEnabled,
+                notificationsFrequency = givenParam.notificationsFrequency,
+            )
+        )
+    }
+} 

--- a/onboarding/src/test/kotlin/net/opatry/h2go/onboarding/presentation/PreferencesViewModelTest.kt
+++ b/onboarding/src/test/kotlin/net/opatry/h2go/onboarding/presentation/PreferencesViewModelTest.kt
@@ -1,0 +1,189 @@
+/*
+ * Copyright (c) 2025 Olivier Patry
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the Software
+ * is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE
+ * OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package net.opatry.h2go.onboarding.presentation
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import net.opatry.h2go.onboarding.domain.SaveInitialUserPreferencesUseCase
+import net.opatry.h2go.preference.domain.VolumeUnit
+import net.opatry.test.util.MainDispatcherExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.Mockito.lenient
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.given
+import org.mockito.kotlin.verify
+import kotlin.time.Duration.Companion.hours
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@ExtendWith(MockitoExtension::class, MainDispatcherExtension::class)
+class PreferencesViewModelTest {
+
+    companion object {
+        @JvmStatic
+        fun saveErrorTestCases() = arrayOf(
+            RuntimeException() to "Unknown error",
+            IllegalArgumentException("Some error") to "Some error",
+        ).map { (givenException, expectedMessage) ->
+            Arguments.of(givenException, expectedMessage)
+        }
+    }
+
+    @Mock
+    private lateinit var useCase: SaveInitialUserPreferencesUseCase
+
+    @Mock
+    private lateinit var mapper: UserVolumeUnitMapper
+
+    @InjectMocks
+    private lateinit var viewModel: PreferencesViewModel
+
+    @BeforeEach
+    fun stubVolumeUnitMapper() {
+        lenient().`when`(mapper.toDomain(UserVolumeUnit.Milliliter)).thenReturn(VolumeUnit.Milliliter)
+        lenient().`when`(mapper.toDomain(UserVolumeUnit.Oz)).thenReturn(VolumeUnit.Oz)
+    }
+
+    @Test
+    fun `given default state, when updating volume unit, then should update state accordingly`() = runTest {
+        // Given
+
+        // When
+        assertThat(viewModel.uiState.value.selectedVolumeUnit).isEqualTo(UserVolumeUnit.Milliliter)
+        viewModel.updateVolumeUnit(UserVolumeUnit.Oz)
+
+        // Then
+        assertThat(viewModel.uiState.value.selectedVolumeUnit).isEqualTo(UserVolumeUnit.Oz)
+    }
+
+    @Test
+    fun `given default state, when enabling notifications, then should update state accordingly`() = runTest {
+        // Given
+
+        // When
+        assertThat(viewModel.uiState.value.areNotificationsEnabled).isTrue()
+        viewModel.enableNotifications(false)
+
+        // Then
+        assertThat(viewModel.uiState.value.areNotificationsEnabled).isFalse()
+    }
+
+    @Test
+    fun `given default state, when updating notification frequency, then should update state accordingly`() = runTest {
+        // Given
+
+        // When
+        assertThat(viewModel.uiState.value.notificationsFrequency).isEqualTo(2.hours)
+        viewModel.updateNotificationsFrequency(4.hours)
+
+        // Then
+        assertThat(viewModel.uiState.value.notificationsFrequency).isEqualTo(4.hours)
+    }
+
+    @Test
+    fun `given default state, when saving preferences, then should trigger use case and navigates to main`() = runTest {
+        // Given
+        val collectedStates = mutableListOf<PreferencesUiState>()
+        val stateCollectorJob = launch(UnconfinedTestDispatcher()) {
+            viewModel.uiState.toList(collectedStates)
+        }
+        val collectedEvents = mutableListOf<PreferencesEvent>()
+        val eventCollectorJob = launch {
+            viewModel.eventsFlow.toList(collectedEvents)
+        }
+
+        // When
+        viewModel.savePreferences()
+
+        // Then
+        val defaultState = viewModel.uiState.value
+        advanceUntilIdle()
+        stateCollectorJob.cancel()
+        eventCollectorJob.cancel()
+
+        assertThat(collectedStates).containsExactly(
+            defaultState,
+            defaultState.copy(isSaving = true),
+            defaultState.copy(isSaving = false),
+        )
+        assertThat(collectedEvents).containsExactly(PreferencesEvent.NavigateToMain)
+
+        verify(useCase).invoke(
+            volumeUnit = VolumeUnit.Milliliter,
+            areNotificationsEnabled = true,
+            notificationsFrequency = 2.hours,
+        )
+    }
+
+    @ParameterizedTest(name = "with {0} message, then should show {1}")
+    @MethodSource("saveErrorTestCases")
+    fun `given default state, when save preferences fails, then should notify error`(
+        givenException: Exception,
+        expectedErrorMessage: String,
+    ) = runTest {
+        // Given
+        given(
+            useCase.invoke(
+                volumeUnit = VolumeUnit.Milliliter,
+                areNotificationsEnabled = true,
+                notificationsFrequency = 2.hours,
+            )
+        ).willThrow(givenException)
+
+        val collectedStates = mutableListOf<PreferencesUiState>()
+        val stateCollectorJob = launch(UnconfinedTestDispatcher()) {
+            viewModel.uiState.toList(collectedStates)
+        }
+        val collectedEvents = mutableListOf<PreferencesEvent>()
+        val eventCollectorJob = launch {
+            viewModel.eventsFlow.toList(collectedEvents)
+        }
+
+        // When
+        viewModel.savePreferences()
+
+        // Then
+        val defaultState = viewModel.uiState.value
+        advanceUntilIdle()
+        stateCollectorJob.cancel()
+        eventCollectorJob.cancel()
+
+        assertThat(collectedStates).containsExactly(
+            defaultState,
+            defaultState.copy(isSaving = true),
+            defaultState.copy(isSaving = false),
+        )
+        assertThat(collectedEvents).containsExactly(PreferencesEvent.Error(expectedErrorMessage))
+    }
+}

--- a/onboarding/src/test/kotlin/net/opatry/h2go/onboarding/presentation/UserVolumeUnitMapperTest.kt
+++ b/onboarding/src/test/kotlin/net/opatry/h2go/onboarding/presentation/UserVolumeUnitMapperTest.kt
@@ -1,0 +1,63 @@
+package net.opatry.h2go.onboarding.presentation
+
+import androidx.annotation.StringRes
+import net.opatry.h2go.onboarding.R
+import net.opatry.h2go.preference.domain.VolumeUnit
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+
+class UserVolumeUnitMapperTest {
+
+    companion object {
+        @JvmStatic
+        fun volumeUnitParams() = arrayOf(
+            VolumeUnit.Milliliter to UserVolumeUnit.Milliliter,
+            VolumeUnit.Oz to UserVolumeUnit.Oz,
+        ).map { (domainUnit, presentationUnit) ->
+            Arguments.of(domainUnit, presentationUnit)
+        }
+
+        @JvmStatic
+        fun unitLabelResParams() = arrayOf(
+            UserVolumeUnit.Milliliter to R.string.onboarding_preferences_volume_unit_ml,
+            UserVolumeUnit.Oz to R.string.onboarding_preferences_volume_unit_oz,
+        ).map { (unit, labelRes) ->
+            Arguments.of(unit, labelRes)
+        }
+    }
+
+    private val mapper = UserVolumeUnitMapper()
+
+    @ParameterizedTest(name = "given domain {0}, then should map to presentation {1}")
+    @MethodSource("volumeUnitParams")
+    fun toPresentation(
+        givenDomainUnit: VolumeUnit,
+        presentationUnit: UserVolumeUnit,
+    ) {
+        assertThat(mapper.toPresentation(givenDomainUnit)).isEqualTo(presentationUnit)
+    }
+
+    @ParameterizedTest(name = "given presentation {1}, then should map to domain {1}")
+    @MethodSource("volumeUnitParams")
+    fun toDomain(
+        domainUnit: VolumeUnit,
+        givenPresentationUnit: UserVolumeUnit,
+    ) {
+        assertThat(mapper.toDomain(givenPresentationUnit)).isEqualTo(domainUnit)
+    }
+
+    @ParameterizedTest(name = "given {1}, then should map to proper label res")
+    @MethodSource("unitLabelResParams")
+    fun `given Oz, then should return oz string resource as unit`(
+        givenUnit: UserVolumeUnit,
+        @StringRes expectedLabelRes: Int,
+    ) {
+        // When
+        val unitLabelRes = givenUnit.labelRes
+
+        // Then
+        assertThat(unitLabelRes).isEqualTo(expectedLabelRes)
+    }
+}

--- a/onboarding/src/test/kotlin/net/opatry/h2go/onboarding/presentation/WelcomeViewModelTest.kt
+++ b/onboarding/src/test/kotlin/net/opatry/h2go/onboarding/presentation/WelcomeViewModelTest.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2025 Olivier Patry
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the Software
+ * is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE
+ * OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package net.opatry.h2go.onboarding.presentation
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import net.opatry.h2go.onboarding.domain.CheckUserPreferencesExistUseCase
+import net.opatry.test.util.MainDispatcherExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.given
+
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@ExtendWith(MockitoExtension::class, MainDispatcherExtension::class)
+class WelcomeViewModelTest {
+
+    @Mock
+    private lateinit var useCase: CheckUserPreferencesExistUseCase
+
+    @InjectMocks
+    private lateinit var viewModel: WelcomeViewModel
+
+    @Test
+    fun `given already defined preferences, when checking user preferences, then should navigate to main`() = runTest {
+        // Given
+        given(useCase.invoke()).willReturn(true)
+
+        // When
+        viewModel.checkUserPreferences()
+
+        // Then
+        assertThat(viewModel.uiState.value).isEqualTo(WelcomeUiState.Idle)
+        advanceUntilIdle()
+        assertThat(viewModel.uiState.value).isEqualTo(WelcomeUiState.NavigateToMain)
+    }
+
+    @Test
+    fun `given no defined preferences, when checking user preferences, then should show welcome`() = runTest {
+        // Given
+        given(useCase.invoke()).willReturn(false)
+
+        // When
+        viewModel.checkUserPreferences()
+
+        // Then
+        assertThat(viewModel.uiState.value).isEqualTo(WelcomeUiState.Idle)
+        advanceUntilIdle()
+        assertThat(viewModel.uiState.value).isEqualTo(WelcomeUiState.ShowWelcome)
+    }
+}

--- a/preferences/build.gradle.kts
+++ b/preferences/build.gradle.kts
@@ -54,5 +54,5 @@ dependencies {
     testImplementation(libs.androidx.room.runtime.jvm)
     testImplementation(libs.androidx.sqlite.bundled.jvm)
     testRuntimeOnly(libs.androidx.sqlite.jvm)
-    implementation(libs.koin.test)
+    testImplementation(libs.koin.test)
 }

--- a/preferences/src/main/kotlin/net/opatry/h2go/preference/domain/UserPreferences.kt
+++ b/preferences/src/main/kotlin/net/opatry/h2go/preference/domain/UserPreferences.kt
@@ -22,10 +22,12 @@
 
 package net.opatry.h2go.preference.domain
 
+import kotlin.time.Duration
+
 data class UserPreferences(
     val dailyTarget: Int,
     val glassVolume: Int,
     val volumeUnit: VolumeUnit,
     val areNotificationsEnabled: Boolean,
-    val notificationFrequencyInHours: Int,
+    val notificationsFrequency: Duration,
 )

--- a/preferences/src/test/kotlin/net/opatry/h2go/preference/data/UserPreferencesMapperTest.kt
+++ b/preferences/src/test/kotlin/net/opatry/h2go/preference/data/UserPreferencesMapperTest.kt
@@ -29,6 +29,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
+import kotlin.time.Duration.Companion.hours
 
 class UserPreferencesMapperTest {
 
@@ -70,7 +71,7 @@ class UserPreferencesMapperTest {
         assertThat(result.glassVolume).isEqualTo(250)
         assertThat(result.volumeUnit).isEqualTo(volumeUnit)
         assertThat(result.areNotificationsEnabled).isEqualTo(areNotificationsEnabled)
-        assertThat(result.notificationFrequencyInHours).isEqualTo(2)
+        assertThat(result.notificationsFrequency).isEqualTo(2.hours)
     }
 
     @ParameterizedTest(name = "given volumeUnit={0} and areNotificationsEnabled={1}, then should map correctly")
@@ -86,7 +87,7 @@ class UserPreferencesMapperTest {
             glassVolume = 300,
             volumeUnit = volumeUnit,
             areNotificationsEnabled = areNotificationsEnabled,
-            notificationFrequencyInHours = 3,
+            notificationsFrequency = 3.hours,
         )
 
         // When

--- a/preferences/src/test/kotlin/net/opatry/h2go/preference/data/UserPreferencesMapperTest.kt
+++ b/preferences/src/test/kotlin/net/opatry/h2go/preference/data/UserPreferencesMapperTest.kt
@@ -53,6 +53,7 @@ class UserPreferencesMapperTest {
         volumeUnitStr: String,
         areNotificationsEnabled: Boolean
     ) {
+        // Given
         val entity = UserPreferencesEntity(
             dailyTarget = 2000,
             glassVolume = 250,
@@ -61,8 +62,10 @@ class UserPreferencesMapperTest {
             notificationFrequencyInHours = 2
         )
 
+        // When
         val result = mapper.toDomain(entity)
 
+        // Then
         assertThat(result.dailyTarget).isEqualTo(2000)
         assertThat(result.glassVolume).isEqualTo(250)
         assertThat(result.volumeUnit).isEqualTo(volumeUnit)
@@ -70,13 +73,14 @@ class UserPreferencesMapperTest {
         assertThat(result.notificationFrequencyInHours).isEqualTo(2)
     }
 
-    @ParameterizedTest(name = "given volumeUnit=${0} and areNotificationsEnabled=${1}, then should map correctly")
+    @ParameterizedTest(name = "given volumeUnit={0} and areNotificationsEnabled={1}, then should map correctly")
     @MethodSource("preferencesParams")
     fun `toEntity should map correctly`(
         volumeUnit: VolumeUnit,
         volumeUnitStr: String,
         areNotificationsEnabled: Boolean
     ) {
+        // Given
         val preferences = UserPreferences(
             dailyTarget = 1500,
             glassVolume = 300,
@@ -85,8 +89,10 @@ class UserPreferencesMapperTest {
             notificationFrequencyInHours = 3,
         )
 
+        // When
         val result = mapper.toEntity(preferences)
 
+        // Then
         assertThat(result.dailyTarget).isEqualTo(1500)
         assertThat(result.glassVolume).isEqualTo(300)
         assertThat(result.volumeUnit).isEqualTo(volumeUnitStr)

--- a/preferences/src/test/kotlin/net/opatry/h2go/preference/data/UserPreferencesRepositoryTest.kt
+++ b/preferences/src/test/kotlin/net/opatry/h2go/preference/data/UserPreferencesRepositoryTest.kt
@@ -35,6 +35,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import kotlin.time.Duration.Companion.hours
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class UserPreferencesRepositoryTest {
@@ -103,7 +104,7 @@ class UserPreferencesRepositoryTest {
         )
 
         // When
-        val updatedPreferences = UserPreferences(1800, 200, VolumeUnit.Oz, false, 4)
+        val updatedPreferences = UserPreferences(1800, 200, VolumeUnit.Oz, false, 4.hours)
         repository.updateUserPreferences(updatedPreferences)
 
         // Then
@@ -125,7 +126,7 @@ class UserPreferencesRepositoryTest {
         )
 
         // When
-        val defaultPreferences = UserPreferences(2000, 25, VolumeUnit.Milliliter, true, 2)
+        val defaultPreferences = UserPreferences(2000, 25, VolumeUnit.Milliliter, true, 2.hours)
         repository.resetUserPreferences(defaultPreferences)
 
         // Then

--- a/preferences/src/test/kotlin/net/opatry/h2go/preference/di/PreferencesModuleTest.kt
+++ b/preferences/src/test/kotlin/net/opatry/h2go/preference/di/PreferencesModuleTest.kt
@@ -34,7 +34,7 @@ import org.koin.test.verify.verify
 class PreferencesModuleTest {
 
     @Test
-    fun `verify logging module`() {
+    fun `verify preference module`() {
         preferencesModule.verify(
             injections = injectedParameters(
                 definition<UserPreferencesRepositoryImpl>(UserPreferencesDao::class),

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -44,4 +44,5 @@ rootProject.name = "H2Go"
 
 include(":h2go-app")
 include(":preferences") 
+include(":onboarding")
 include(":test-util")

--- a/test-util/build.gradle.kts
+++ b/test-util/build.gradle.kts
@@ -20,28 +20,16 @@
  * OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-pluginManagement {
-    repositories {
-        google()
-        mavenCentral()
-        gradlePluginPortal()
-    }
+plugins {
+    id("kotlin")
 }
 
-dependencyResolutionManagement {
-    @Suppress("UnstableApiUsage")
-    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
-    @Suppress("UnstableApiUsage")
-    repositories {
-        google()
-        mavenCentral()
-    }
+kotlin {
+    jvmToolchain(17)
 }
 
-enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
-
-rootProject.name = "H2Go"
-
-include(":h2go-app")
-include(":preferences") 
-include(":test-util")
+dependencies {
+    implementation(libs.kotlinx.coroutines.core)
+    implementation(libs.kotlinx.coroutines.test)
+    implementation(libs.junit)
+}

--- a/test-util/src/main/kotlin/net/opatry/test/util/MainDispatcherExtension.kt
+++ b/test-util/src/main/kotlin/net/opatry/test/util/MainDispatcherExtension.kt
@@ -1,0 +1,20 @@
+package net.opatry.test.util
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.jupiter.api.extension.AfterAllCallback
+import org.junit.jupiter.api.extension.BeforeAllCallback
+import org.junit.jupiter.api.extension.ExtensionContext
+
+@ExperimentalCoroutinesApi
+class MainDispatcherExtension : BeforeAllCallback, AfterAllCallback {
+    override fun beforeAll(context: ExtensionContext?) {
+        Dispatchers.setMain(StandardTestDispatcher())
+    }
+    override fun afterAll(context: ExtensionContext?) {
+        Dispatchers.resetMain()
+    }
+}


### PR DESCRIPTION
- Add `:onboarding` module to manage
  - left for later:
    - share preference logic & screen (ex: default preferences, reusable components for "in-app" preferences screen) (see #12)
    - request user gender (impacts default volume) (see #13)
    - determine default preferences (taking into account Locale & gender) (see #13)
    - nice UI
    - UI components unit tests (see #12)
- Add `MainNavigation` to `MainActivity`
